### PR TITLE
Fixes the event info bug

### DIFF
--- a/func_adl_xAOD/atlas/xaod/event_collections.py
+++ b/func_adl_xAOD/atlas/xaod/event_collections.py
@@ -9,7 +9,7 @@ class atlas_xaod_event_collection_container(event_collection_container):
         super().__init__(type_name, is_pointer)
 
     def __str__(self):
-        return f"edm::Handle<{self._type_name}>"
+        return f"const {self._type_name} *"
 
 
 class atlas_xaod_event_collection_collection(event_collection_collection):

--- a/tests/atlas/xaod/test_integrated_query.py
+++ b/tests/atlas/xaod/test_integrated_query.py
@@ -157,6 +157,15 @@ def test_md_job_options():
     assert int(training_df.iloc[0]['JetPt']) != int(training_df.iloc[1]['JetPt'])  # type: ignore
 
 
+def test_event_info_includes():
+    'Make sure event info is pulling in the correct includes'
+    training_df = as_pandas(f_single
+                            .Select(lambda e: e.EventInfo("EventInfo"))
+                            .Select(lambda e: e.runNumber()))
+    print(training_df)
+    assert len(training_df) == 10
+
+
 def test_single_column_output():
     # And a power operator
     training_df = as_pandas(f_single


### PR DESCRIPTION
A bug was introduced at some point that meant the `EventInfo` object was no loger accessible. This fixes that

## Approach

* Change from referencing `edm::Handle` to directly looking at a const pointer.