### PR TITLE
Don't duplicate library or include files

### DIFF
--- a/func_adl_xAOD/common/generated_code.py
+++ b/func_adl_xAOD/common/generated_code.py
@@ -65,13 +65,15 @@ class generated_code:
             below.add_statement(st)
 
     def add_include(self, path):
-        self._include_files += [path]
+        if path not in self._include_files:
+            self._include_files += [path]
 
     def include_files(self):
         return self._include_files
 
     def add_link_library(self, library: str):
-        self._link_libraries += [library]
+        if library not in self._link_libraries:
+            self._link_libraries += [library]
 
     def link_libraries(self) -> List[str]:
         return self._link_libraries

--- a/tests/common/test_generated_code.py
+++ b/tests/common/test_generated_code.py
@@ -87,3 +87,22 @@ def test_get_rep_hidden():
     assert 10 == g.get_rep("dude")
     g.pop_scope()
     assert 5 == g.get_rep("dude")
+
+
+def test_add_include():
+    g = generated_code()
+    g.add_include("example_include")
+    assert "example_include" in g.include_files()
+
+    g.add_include("example_include")
+    assert len(g.include_files()) == 1
+
+
+def test_add_link_library():
+    g = generated_code()
+
+    g.add_link_library("example_library")
+    assert "example_library" in g.link_libraries()
+
+    g.add_link_library("example_library")
+    assert len(g.link_libraries()) == 1


### PR DESCRIPTION
* Prevent include files from being emitted multiple times in the same file.
* Same for link libraries.

Fixes #247