### PR TITLE
fix: Use cmake_minimum_required policy_max

### DIFF
--- a/func_adl_xAOD/template/atlas/r21/runner.sh
+++ b/func_adl_xAOD/template/atlas/r21/runner.sh
@@ -70,7 +70,7 @@ if [ $compile = 1 ]; then
 project(func_adl_ntupler)
 
 # Set the minimum required CMake version:
-cmake_minimum_required( VERSION 4.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 3.12...4.3 )
 
 # Try to figure out what project is our parent. Just using a hard-coded list
 # of possible project names. Basically the names of all the other


### PR DESCRIPTION
* Set policy_max which defines the maximum CMake policy. cmake_minimum_required sets two minimums: the real (lower) minimum and the (upper) minimum based on has been tested with. The defaults (CMake policies) will be set to the highest value possible between the two values. Without policy_max, and just a single version, that **locks the CMake Policy** to use that and **only** that policy.
   - c.f. https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html
* FATAL_ERROR has been ignored fully as of CMake v2.6+ and so is removed.
* Amends PR https://github.com/iris-hep/func_adl_xAOD/pull/282

---

:wave: I noticed this when comparing https://github.com/conda-forge/func-adl-xaod-feedstock/pull/3#pullrequestreview-4088066375, so thought I'd open up a small PR that should make CMake use much more stable for many more years.