### PR TITLE
Use glob to source platform setup.sh in r21 runner.sh

### DIFF
--- a/func_adl_xAOD/template/atlas/r21/runner.sh
+++ b/func_adl_xAOD/template/atlas/r21/runner.sh
@@ -172,7 +172,7 @@ fi
 
 # Sort out the input file location
 if [ $run = 1 ]; then
-   source ${AnalysisBaseExternals_PLATFORM}/setup.sh
+   source x86_64*/setup.sh
    if [ "$input_method" == "filelist" ]; then
       if [ -e $DIR/filelist.txt ]; then
          cp $DIR/filelist.txt .


### PR DESCRIPTION
## Summary
- In `func_adl_xAOD/template/atlas/r21/runner.sh`, replace `source ${AnalysisBaseExternals_PLATFORM}/setup.sh` with `source x86_64*/setup.sh` so the platform setup script is located by glob rather than relying on the `AnalysisBaseExternals_PLATFORM` environment variable being set in the build environment.

## Test plan
- [x] `pytest -m atlas_xaod_runner tests/atlas/xaod/test_local_dataset.py::test_integrated_run` passes locally (full container build + execute against `atlas/analysisbase:21.2.197`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)